### PR TITLE
chore: fix semantic versioning for wildcard identifier (#5105)

### DIFF
--- a/src/sagemaker/jumpstart/cache.py
+++ b/src/sagemaker/jumpstart/cache.py
@@ -552,6 +552,12 @@ class JumpStartModelsCache:
                 )
             return version_str if version_str in available_versions else None
 
+        if version_str[-1] == "*":
+            # major or minor version is pinned, e.g 1.* or 1.0.*
+            return utils.get_latest_version(
+                [version for version in available_versions if version.startswith(version_str[:-1])]
+            )
+
         try:
             spec = SpecifierSet(f"=={version_str}")
         except InvalidSpecifier:

--- a/tests/unit/sagemaker/jumpstart/constants.py
+++ b/tests/unit/sagemaker/jumpstart/constants.py
@@ -15990,6 +15990,18 @@ BASE_MANIFEST = [
         "spec_key": "community_models_specs/tensorflow-ic-"
         "imagenet-inception-v3-classification-4/specs_v3.0.0.json",
     },
+    {
+        "model_id": "meta-textgeneration-llama-2-7b",
+        "version": "4.9.0",
+        "min_version": "2.49.0",
+        "spec_key": "community_models/meta-textgeneration-llama-2-7b/specs_v4.9.0.json",
+    },
+    {
+        "model_id": "meta-textgeneration-llama-2-7b",
+        "version": "4.13.0",
+        "min_version": "2.49.0",
+        "spec_key": "community_models/meta-textgeneration-llama-2-7b/specs_v4.13.0.json",
+    },
 ]
 
 BASE_PROPRIETARY_HEADER = {

--- a/tests/unit/sagemaker/jumpstart/test_cache.py
+++ b/tests/unit/sagemaker/jumpstart/test_cache.py
@@ -186,6 +186,30 @@ def test_jumpstart_cache_get_header():
 
     assert JumpStartModelHeader(
         {
+            "model_id": "meta-textgeneration-llama-2-7b",
+            "version": "4.13.0",
+            "min_version": "2.49.0",
+            "spec_key": "community_models/meta-textgeneration-llama-2-7b/specs_v4.13.0.json",
+        }
+    ) == cache.get_header(
+        model_id="meta-textgeneration-llama-2-7b",
+        semantic_version_str="*",
+    )
+
+    assert JumpStartModelHeader(
+        {
+            "model_id": "meta-textgeneration-llama-2-7b",
+            "version": "4.13.0",
+            "min_version": "2.49.0",
+            "spec_key": "community_models/meta-textgeneration-llama-2-7b/specs_v4.13.0.json",
+        }
+    ) == cache.get_header(
+        model_id="meta-textgeneration-llama-2-7b",
+        semantic_version_str="4.*",
+    )
+
+    assert JumpStartModelHeader(
+        {
             "model_id": "ai21-summarization",
             "version": "1.1.003",
             "min_version": "2.0.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)
- [ ] If adding any dependency in requirements.txt files, I have spell checked and ensured they exist in PyPi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
